### PR TITLE
feat: Preprocess DETR dataset

### DIFF
--- a/detr_dataset.ipynb
+++ b/detr_dataset.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": "!pip install -U -q datasets transformers[torch] timm wandb torchmetrics\n"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.read_csv(\"Train.csv\")\n",
+    "df.head()"
+   ],
+   "id": "86dbe50169a2146d"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "# del class = NEG\n",
+    "df = df[df['class'] != 'NEG']\n",
+    "df.head()\n"
+   ],
+   "id": "450c88051ccabb4d"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "label2id = {'Trophozoite': 0, 'WBC': 1}\n",
+    "id2label = {v: k for k, v in label2id.items()}\n"
+   ],
+   "id": "8d4976020070d278"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "# apply on df\n",
+    "df['label'] = df['class'].map(label2id)\n",
+    "df.head()"
+   ],
+   "id": "8370a70950652b4b"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "# bbox: The object’s bounding box (in the Pascal VOC format) xmin, ymin, xmax, ymax\n",
+    "df['bbox'] = df.apply(lambda row: [row['xmin'], row['ymin'], row['xmax'], row['ymax']], axis=1) xmin, ymin, xmax, ymax\n",
+    "df.head()"
+   ],
+   "id": "3d4bac7987fe7a20"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import pandas as pd\n",
+    "from PIL import Image\n",
+    "import os\n",
+    "from datasets import ClassLabel, Sequence, Value\n",
+    "import uuid\n",
+    "\n",
+    "\n",
+    "def get_image_path(image_id):\n",
+    "    return f\"/content/images/{image_id}\"\n",
+    "\n",
+    "def get_image_dimensions(image_path):\n",
+    "    with Image.open(image_path) as img:\n",
+    "        return img.size\n",
+    "\n",
+    "def process_group(group):\n",
+    "    image_id = group.name\n",
+    "    image_path = get_image_path(image_id)\n",
+    "\n",
+    "    # Get image dimensions without loading the entire image\n",
+    "    width, height = get_image_dimensions(image_path)\n",
+    "\n",
+    "    bbox_ids = []\n",
+    "    categories = []\n",
+    "    bboxes = []\n",
+    "    areas = []\n",
+    "\n",
+    "    for i, (_, row) in enumerate(group.iterrows()):\n",
+    "        bbox = row['bbox']\n",
+    "        area = (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])\n",
+    "\n",
+    "        bbox_ids.append(f\"{image_id}_{i:04d}\")\n",
+    "        categories.append(row['label'])\n",
+    "        bboxes.append(bbox)\n",
+    "        areas.append(area)\n",
+    "\n",
+    "    objects = {\n",
+    "            'bbox_id': bbox_ids,\n",
+    "            'category': categories,\n",
+    "            'bbox': bboxes,\n",
+    "            'area': areas\n",
+    "    }\n",
+    "    image_id_int = hash(image_id)\n",
+    "    return pd.Series({\n",
+    "            'image_id':  image_id_int\n",
+    "            ,\n",
+    "            'image': image_path,  # Store the image path instead of the PIL Image object\n",
+    "            'width': width,\n",
+    "            'height': height,\n",
+    "            'objects': objects\n",
+    "    })\n",
+    "\n",
+    "# Process the DataFrame\n",
+    "def process_dataframe(df):\n",
+    "    return df.groupby('Image_ID').apply(process_group).reset_index(drop=True)\n",
+    "\n",
+    "# Process the dataframe\n",
+    "new_df = process_dataframe(df)\n",
+    "\n",
+    "# Define the schema\n",
+    "schema = {\n",
+    "        'image_id': Value(dtype='int64'),\n",
+    "        'image': Value(dtype='string'),  # Now it's a string (path) instead of PIL Image\n",
+    "        'width': Value(dtype='int64'),\n",
+    "        'height': Value(dtype='int64'),\n",
+    "        'objects': {\n",
+    "                'bbox_id': Sequence(Value(dtype='string')),\n",
+    "                'category': Sequence(Value(dtype='int64')),\n",
+    "                'bbox': Sequence(Sequence(Value(dtype='float64'), length=4)),\n",
+    "                'area': Sequence(Value(dtype='float64'))\n",
+    "        }\n",
+    "}\n",
+    "\n",
+    "# Print the first few rows to verify the structure\n",
+    "print(new_df.head())\n",
+    "\n",
+    "# Example of accessing data\n",
+    "first_row = new_df.iloc[0]\n",
+    "print(f\"Image ID: {first_row['image_id']}\")\n",
+    "print(f\"Image path: {first_row['image']}\")\n",
+    "print(f\"Image dimensions: {first_row['width']}x{first_row['height']}\")\n",
+    "print(\"Objects:\")\n",
+    "print(f\"  bbox_ids: {first_row['objects']['bbox_id']}\")\n",
+    "print(f\"  categories: {first_row['objects']['category']}\")\n",
+    "print(f\"  bboxes: {first_row['objects']['bbox']}\")\n",
+    "print(f\"  areas: {first_row['objects']['area']}\")\n",
+    "\n",
+    "# Function to load image on demand\n",
+    "def load_image(image_path):\n",
+    "    return Image.open(image_path)\n",
+    "\n",
+    "# Example of loading an image on demand\n",
+    "# first_image = load_image(new_df.iloc[0]['image'])"
+   ],
+   "id": "ea287262d82c927f"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "from datasets import Dataset, Features, Value, Sequence, Image\n",
+    "\n",
+    "\n",
+    "# Define the schema (Features)\n",
+    "features = Features({\n",
+    "        'image_id': Value(dtype='int64'),\n",
+    "        'image': Image(decode=True),  # This will be the image path initially\n",
+    "        'width': Value(dtype='int64'),\n",
+    "        'height': Value(dtype='int64'),\n",
+    "        'objects': {\n",
+    "                'bbox_id': Sequence(Value(dtype='string')),\n",
+    "                'category': Sequence(Value(dtype='int64')),\n",
+    "                'bbox': Sequence(Sequence(Value(dtype='float64'), length=4)),\n",
+    "                'area': Sequence(Value(dtype='float64'))\n",
+    "        }\n",
+    "})\n",
+    "\n",
+    "# Convert DataFrame to Hugging Face Dataset\n",
+    "hf_dataset = Dataset.from_pandas(new_df, features=features)"
+   ],
+   "id": "5eda4e33c2999b00"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "hf_dataset.push_to_hub('jonathansuru/ano4')",
+   "id": "1fff3a6e80abf6ec"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
feat: Preprocess DETR dataset

This pull request introduces a new notebook for preprocessing the DETR dataset. The key changes are:

1. Removes samples with 'NEG' class from the dataset.
2. Maps the 'class' column to a numerical 'label' column using a label-to-id mapping.
3. Extracts the bounding box coordinates from the individual columns and stores them in a single 'bbox' column.
4. Processes the DataFrame to create a new DataFrame with the following structure:
   - `image_id`: A unique identifier for each image.
   - `image`: The path to the image file.
   - `width`: The width of the image.
   - `height`: The height of the image.
   - `objects`: A dictionary containing information about the objects in the image, including the bounding box coordinates, category, and area.
5. Defines a schema for the new DataFrame to facilitate its use with the `datasets` library.

This preprocessing step ensures the dataset is in a format that can be easily used for training a DETR model.